### PR TITLE
fix: Handle limit exceeded error and show user

### DIFF
--- a/email_delivery_service/controller.py
+++ b/email_delivery_service/controller.py
@@ -26,8 +26,8 @@ def send(self, sender, recipient, msg):
 	else:
 		try:
 			error = resp.json()
-			exc_type = error.get["exc_type"]
-			exception = error.get["exception"]
+			exc_type = error["exc_type"]
+			exception = error["exception"]
 			frappe.throw(exc=exc_type, msg=exception)
 		except (json.decoder.JSONDecodeError, KeyError):
 			error = resp.text

--- a/email_delivery_service/controller.py
+++ b/email_delivery_service/controller.py
@@ -21,12 +21,17 @@ def send(self, sender, recipient, msg):
 		data={"data": json.dumps(data)},
 		files=files,
 	)
-
 	if resp.status_code == 200:
-		resp = json.loads(resp.text)
 		update_queue_status(self, "Sending", commit=True)
 	else:
-		update_queue_status(self, "Error", resp.exc, commit=True)
+		try:
+			error = resp.json().get("exc")
+		except json.decoder.JSONDecodeError:
+			error = resp.text
+		try:
+			update_queue_status(self, "Error", error, commit=True)
+		except Exception as e:
+			frappe.log_error("Error updating queue status", e)
 
 
 @frappe.whitelist(allow_guest=True)

--- a/email_delivery_service/controller.py
+++ b/email_delivery_service/controller.py
@@ -57,10 +57,8 @@ def update_status(**data):
 	return
 
 
-def update_queue_status(queue, status, error=None, commit=False):
+def update_queue_status(queue, status, commit=False):
 	frappe.db.set_value("Email Queue", queue.name, "status", status)
-	if error:
-		frappe.db.set_value("Email Queue", queue.name, "error", error)
 	if commit:
 		frappe.db.commit()
 	if queue.communication:

--- a/email_delivery_service/controller.py
+++ b/email_delivery_service/controller.py
@@ -28,7 +28,7 @@ def send(self, sender, recipient, msg):
 			error = json.dumps(json.loads(resp.text), indent=4)
 		except json.decoder.JSONDecodeError:
 			error = resp.text
-		frappe.throw("Error sending email", error)
+		frappe.throw(f"Error sending email: {error}")
 
 
 @frappe.whitelist(allow_guest=True)

--- a/email_delivery_service/controller.py
+++ b/email_delivery_service/controller.py
@@ -28,10 +28,10 @@ def send(self, sender, recipient, msg):
 			error = resp.json()
 			exc_type = error.get["exc_type"]
 			exception = error.get["exception"]
-			raise Exception(exc_type, exception)
+			frappe.throw(exc=exc_type, msg=exception)
 		except (json.decoder.JSONDecodeError, KeyError):
 			error = resp.text
-			raise Exception(error)
+			frappe.throw(error, requests.HTTPError)
 
 
 @frappe.whitelist(allow_guest=True)

--- a/email_delivery_service/controller.py
+++ b/email_delivery_service/controller.py
@@ -25,10 +25,13 @@ def send(self, sender, recipient, msg):
 		update_queue_status(self, "Sending", commit=True)
 	else:
 		try:
-			error = json.dumps(json.loads(resp.text), indent=4)
-		except json.decoder.JSONDecodeError:
+			error = resp.json()
+			exc_type = error.get["exc_type"]
+			exception = error.get["exception"]
+			raise Exception(exc_type, exception)
+		except (json.decoder.JSONDecodeError, KeyError):
 			error = resp.text
-		frappe.throw(f"Error sending email: {error}")
+			raise Exception(error)
 
 
 @frappe.whitelist(allow_guest=True)

--- a/email_delivery_service/controller.py
+++ b/email_delivery_service/controller.py
@@ -25,13 +25,10 @@ def send(self, sender, recipient, msg):
 		update_queue_status(self, "Sending", commit=True)
 	else:
 		try:
-			error = resp.json().get("exc")
+			error = json.dumps(json.loads(resp.text), indent=4)
 		except json.decoder.JSONDecodeError:
 			error = resp.text
-		try:
-			update_queue_status(self, "Error", error, commit=True)
-		except Exception as e:
-			frappe.log_error("Error updating queue status", e)
+		frappe.throw("Error sending email", error)
 
 
 @frappe.whitelist(allow_guest=True)


### PR DESCRIPTION
Set email queue to error on failure to send mime mail. This is done by throwing an exception.
Corresponding error log will have the [exception thrown] by press(https://github.com/frappe/press/blob/bf153258cc6e1c144767bf40738f6b15c5f8c6fc/press/api/email.py#L120-L124) 

Needs https://github.com/frappe/frappe/pull/27632 for error to show in Email Queue